### PR TITLE
fix: check tab.pendingUrl and add a delay to avoid high CPU usage

### DIFF
--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -228,7 +228,10 @@
     function toggleIgnoreIcon(tab, url) {
         if (!url) {
             browser.tabs.get(tab, function (tab) {
-                if (tab) toggleIgnoreIcon(tab.id, tab.url);
+                if (tab) {
+                    var url = tab.url || tab.pendingUrl;
+                    setTimeout(toggleIgnoreIcon, url ? 0 : 500, tab.id, url);
+                }
             });
         } else {
             var icon;


### PR DESCRIPTION
In some cases the navigation cannot be performed immediately, e.g. slow network connection, waiting for IPFS to resolve. As a result, `tab.url` will be empty and the URL to be navigated is in `tab.pendingUrl`. See [the docs](https://developer.chrome.com/docs/extensions/reference/tabs/#type-Tab).

In such cases, this extension will try to check `tab.url` infinitely without any delay, leading to high CPU usage (around 100%) and computer fan noise.

The fix is to check `pendingUrl` as well as `url`, and if that fails too, add a delay before the next check.