### PR TITLE
switch to old tab if active is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ Temporary Items
 *.pem
 *.psd
 chrome/*.zip
+node_modules

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It is also possible to configure whether you prefer to close the oldest tabs and
 Configuration | Description
 --- | ---
 `close olders` | Close the old tabs and keep the most recent one with the same URL
-`keep the tab that is active` | Don't close active tabs
+`keep the tab that is active` | Don't close active tabs. If disabled, when the active tab is closed, the browser will switch to the old tab
 
 ### URLs
 

--- a/chrome/_locales/en/messages.json
+++ b/chrome/_locales/en/messages.json
@@ -45,7 +45,7 @@
     "message": "Preserve active tab"
   },
   "keep_active_description": {
-    "message": "Don't close active tabs"
+    "message": "Don't close active tabs. If disabled, when the active tab is closed, the browser will switch to the old tab"
   },
   "urls_title": {
     "message": "URLs"

--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -177,8 +177,19 @@
 
         tabs = tabs.sort(sortTabs);
 
+        var activeWasClosed = false;
+
         for (var i = 1; i < j; i++) {
-            browser.tabs.remove(tabs[i].id, empty);
+            var tab = tabs[i];
+            if (tab.actived) {
+                activeWasClosed = true;
+            }
+            browser.tabs.remove(tab.id, empty);
+        }
+
+
+        if (activeWasClosed) {
+            chrome.tabs.update(tabs[0].id, { active: true });
         }
     }
 

--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -184,7 +184,7 @@
         for (var key in localStorage) {
             if (key.indexOf("data:") === 0) {
                 data.push({
-                    "id": key.substr(5),
+                    "id": key.slice(5),
                     "value": getStorage(key)
                 });
             }

--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -6,6 +6,16 @@
  * https://github.com/brcontainer/prevent-duplicate-tabs
  */
 
+/**
+ * @typedef {"attach" | "create" | "replace" | "update"} TabChangeType
+ */
+
+/**
+ * @typedef TabGroupItem
+ * @prop {number} id
+ * @prop {boolean} actived
+ */
+
 (function (w, u) {
     "use strict";
 
@@ -15,13 +25,16 @@
         w.browser = browser;
     }
 
+    /** @type {IgnoredStorage | undefined} */
     var ignoreds,
+        /** @type {ReturnType<typeof setTimeout>} */
         timeout,
         isHttpRE = /^https?:\/\/\w/i,
         isNewTabRE = /^(about:blank|chrome:\/+?(newtab|startpageshared)\/?)$/i,
         removeHashRE = /#[\s\S]+?$/,
         removeQueryRE = /\?[\s\S]+?$/,
         browser = w.browser,
+        /** @type {ConfigStorage} */
         configs = {
             "turnoff": false,
             "old": true,
@@ -43,18 +56,27 @@
 
     var legacyConfigs = Object.keys(configs);
 
+    /**
+     * @param {TabChangeType} type
+     */
     function checkTabs(type) {
         if (configs[type]) {
             browser.tabs.query(configs.windows ? { "lastFocusedWindow": true } : {}, preGetTabs);
         }
     }
 
+    /**
+     * @param {chrome.tabs.Tab[]} tabs
+     */
     function preGetTabs(tabs) {
         if (timeout) clearTimeout(timeout);
 
         timeout = setTimeout(getTabs, 50, tabs);
     }
 
+    /**
+     * @param {string} url
+     */
     function isIgnored(url) {
         return ignoreds && (ignoreds.urls.indexOf(url) !== -1 || ignoreds.hosts.indexOf(new URL(url).host) !== -1);
     }
@@ -70,12 +92,15 @@
         );
     }
 
+    /**
+     * @param {chrome.tabs.Tab[]} tabs
+     */
     function getTabs(tabs) {
         if (isDisabled()) return;
 
         var tab,
-            url,
-            groupTabs = {},
+            /** @type {string} */ url,
+            /** @type {{[url: string]: TabGroupItem[]}} */ groupTabs = {},
             onlyHttp = configs.http,
             ignoreHash = !configs.hash,
             ignoreQuery = !configs.query,
@@ -130,6 +155,10 @@
         groupTabs = tabs = null;
     }
 
+    /**
+     * @param {TabGroupItem} tab
+     * @param {TabGroupItem} nextTab
+     */
     function sortTabs(tab, nextTab) {
         if (configs.active && (tab.actived || nextTab.actived)) {
             return tab.actived ? -1 : 1;
@@ -138,6 +167,9 @@
         return configs.old && tab.id < nextTab.id ? 1 : -1;
     }
 
+    /**
+     * @param {TabGroupItem[]} tabs
+     */
     function closeTabs(tabs) {
         var j = tabs.length;
 
@@ -150,13 +182,30 @@
         }
     }
 
+    /**
+     * @typedef TabQuery
+     * @prop {number} [id]
+     * @prop {number} [tabId]
+     * @prop {string} [url]
+     */
+
+    /**
+     * @param {TabChangeType} type
+     * @param {number} timeout
+     */
     function createEvent(type, timeout) {
+        /**
+         * @param {TabQuery | TabQuery & number} tab
+         */
         return function (tab) {
             setTimeout(checkTabs, timeout, type);
             setTimeout(toggleIgnoreIcon, 100, tab.id || tab.tabId || tab, tab.url);
         };
     }
 
+    /**
+     * @return {typeof configs}
+     */
     function getConfigs() {
         return {
             "turnoff": getStorage("turnoff", configs.turnoff),
@@ -203,8 +252,14 @@
         };
     }
 
+    /**
+     * @param {'host' | 'url'} type
+     * @param {boolean} ignore
+     * @param {string} value
+     */
     function toggleIgnoreData(type, ignore, value) {
         var changed = true,
+            /** @type {'hosts' | 'urls'} */
             storage = type + "s",
             contents = getStorage(storage);
 
@@ -228,6 +283,10 @@
         contents = null;
     }
 
+    /**
+     * @param {number} tab
+     * @param {string} [url]
+     */
     function toggleIgnoreIcon(tab, url) {
         if (!url) {
             browser.tabs.get(tab, function (tab) {
@@ -252,6 +311,9 @@
         }
     }
 
+    /**
+     * @param {chrome.tabs.Tab[]} tabs
+     */
     function updateCurrentIcon(tabs) {
         if (tabs && tabs[0]) toggleIgnoreIcon(tabs[0].id, tabs[0].url);
     }
@@ -287,6 +349,7 @@
             setStorage(request.setup, request.enable);
             browser.tabs.query({ "active": true, "lastFocusedWindow": true }, updateCurrentIcon);
         } else if (request.data) {
+            /** @type {`data:${string}`} */
             var key = "data:" + request.data;
             configs[key] = request.value;
             setStorage(key, request.value);

--- a/chrome/js/boot.js
+++ b/chrome/js/boot.js
@@ -6,12 +6,64 @@
  * https://github.com/brcontainer/prevent-duplicate-tabs
  */
 
+/** @type {(...args: any[]) => void} */
 function empty() {}
 
+/**
+ * @typedef ConfigStorage
+ * @prop {boolean} turnoff
+ * @prop {boolean} old
+ * @prop {boolean} active
+ * @prop {boolean} start
+ * @prop {boolean} replace
+ * @prop {boolean} update
+ * @prop {boolean} create
+ * @prop {boolean} attach
+ * @prop {boolean} datachange
+ * @prop {boolean} http
+ * @prop {boolean} query
+ * @prop {boolean} hash
+ * @prop {boolean} incognito
+ * @prop {boolean} windows
+ * @prop {boolean} containers
+ */
+
+/**
+ * @typedef IgnoredStorage
+ * @prop {string[]} urls
+ * @prop {string[]} hosts
+ */
+
+/**
+ * @typedef StateStorage
+ * @prop {boolean} firstrun
+ */
+
+/** @typedef {{ [K in `${'data' | 'details'}:${string}`]: any }} ExtraStorage */
+
+/**
+ * @typedef ExtraDataItem
+ * @prop {string} id
+ * @prop {any} value
+ */
+
+/** @typedef {ConfigStorage & IgnoredStorage & StateStorage & ExtraStorage} ExtensionStorage */
+
+/**
+ * @template {keyof ExtensionStorage} K
+ * @param {K} key
+ * @param {ExtensionStorage[K]} value
+ */
 function setStorage(key, value) {
     localStorage.setItem(key, JSON.stringify({ "value": value }));
 }
 
+/**
+ * @template {keyof ExtensionStorage} K
+ * @param {K} key
+ * @param {ExtensionStorage[K]} [fallback]
+ * @returns {ExtensionStorage[K]}
+ */
 function getStorage(key, fallback) {
     var value = localStorage[key];
 
@@ -28,6 +80,71 @@ function runtimeConnected() {
     return !!browser && browser.runtime && browser.runtime.sendMessage;
 }
 
+/**
+ * @typedef ExtensionIgnoreMessage
+ * @prop {never} [setup]
+ * @prop {never} [data]
+ * @prop {'host' | 'url'} type
+ * @prop {boolean} ignore
+ * @prop {string} value
+ * @prop {number} tabId
+ * @prop {string} [url]
+ */
+
+/**
+ * @typedef ExtensionSetupMessage
+ * @prop {never} [ignore]
+ * @prop {never} [data]
+ * @prop {keyof ConfigStorage} setup
+ * @prop {boolean} enable
+ */
+
+/**
+ * @typedef ExtensionDataMessage
+ * @prop {never} [ignore]
+ * @prop {never} [setup]
+ * @prop {'color-scheme'} data
+ * @prop {any} value
+ */
+
+/**
+ * @typedef ExtensionGetMessage
+ * @prop {never} [ignore]
+ * @prop {never} [setup]
+ * @prop {never} [data]
+ * @prop {true} [extra]
+ * @prop {true} [configs]
+ * @prop {true} [ignored]
+ */
+
+/**
+ * @overload
+ * @param {Pick<ExtensionGetMessage, 'extra'>} message
+ * @param {(response: ExtraDataItem[]) => void} callback
+ * @returns {void}
+ */
+/**
+ * @overload
+ * @param {Pick<ExtensionGetMessage, 'configs'>} message
+ * @param {(response: ConfigStorage) => void} callback
+ * @returns {void}
+ */
+/**
+ * @overload
+ * @param {Pick<ExtensionGetMessage, 'ignored'>} message
+ * @param {(response: IgnoredStorage) => void} callback
+ * @returns {void}
+ */
+/**
+ * @overload
+ * @param {ExtensionDataMessage | ExtensionSetupMessage | ExtensionIgnoreMessage} message
+ * @returns {void}
+ */
+/**
+ * @param {ExtensionGetMessage | ExtensionDataMessage | ExtensionSetupMessage | ExtensionIgnoreMessage} message
+ * @param {(response: any) => void} [callback]
+ * @returns {void}
+ */
 function sendMessage(message, callback) {
     if (runtimeConnected()) {
         browser.runtime.sendMessage(null, message, {}, callback || empty);

--- a/chrome/js/color-scheme.js
+++ b/chrome/js/color-scheme.js
@@ -6,8 +6,14 @@
  * https://github.com/brcontainer/prevent-duplicate-tabs
  */
 
+/**
+ * @param {boolean} darkPrefer
+ * @param {string} [userPrefer]
+ */
 function setColorScheme(darkPrefer, userPrefer) {
-    var disable, links = document.querySelectorAll("link[href*='-dark.css']");
+    var disable,
+        /** @type {NodeListOf<HTMLLinkElement>} */
+        links = document.querySelectorAll("link[href*='-dark.css']");
 
     switch (userPrefer || getStorage("data:color-scheme")) {
         case "dark":
@@ -40,6 +46,9 @@ function setColorScheme(darkPrefer, userPrefer) {
         }
     });
 
+    /**
+     * @param {MediaQueryListEvent} e
+     */
     media.onchange = function (e) {
         setColorScheme(e.matches);
     };

--- a/chrome/js/data.js
+++ b/chrome/js/data.js
@@ -25,12 +25,17 @@
             "version": browser.runtime.getManifest().version
         };
 
+    /**
+     * @param {string[]} hosts
+     * @param {string[]} urls
+     */
     function applyIgnoredData(hosts, urls) {
         var http = isHttpRE.test(variables.url);
 
         if (!http) return;
 
         var actions = d.getElementById("actions"),
+            /** @type {NodeListOf<HTMLElement>} */
             ignoreds = d.querySelectorAll("[data-ignored]");
 
         actions.style.display = "block";
@@ -53,6 +58,7 @@
     }
 
     function applyEvents() {
+        /** @type {NodeListOf<HTMLButtonElement>} */
         var els = d.querySelectorAll("[data-ignored] .col:first-child > button");
 
         for (var i = els.length - 1; i >= 0; i--) {
@@ -60,7 +66,11 @@
         }
     }
 
+    /**
+     * @param {MouseEvent} e
+     */
     function addRemoveUrl(e) {
+        /** @type {HTMLElement} */
         var target = e.target;
 
         if (target && w.runtimeConnected()) {
@@ -96,10 +106,10 @@
             query = "var[name]";
         }
 
-        var vars = d.querySelectorAll(query);
+        var varsElements = d.querySelectorAll(query);
 
-        for (var i = vars.length - 1; i >= 0; i--) {
-            var el = vars[i], key = el.getAttribute("name"), value = variables[key];
+        for (var i = varsElements.length - 1; i >= 0; i--) {
+            var el = varsElements[i], key = el.getAttribute("name"), value = variables[key];
 
             if (key && value) {
                 el.textContent = value;

--- a/chrome/js/popup.js
+++ b/chrome/js/popup.js
@@ -25,6 +25,7 @@
         debugMode = true;
     }
 
+    /** @param {Event} e */
     function disableEvent(e) {
         e.preventDefault();
         return false;
@@ -35,6 +36,7 @@
         d.ondragstart = disableEvent;
     }
 
+    /** @param {string} message */
     function markdown(message) {
         return message
                 .replace(/(^|\s|[>])_(.*?)_($|\s|[<])/g, '$1<i>$2<\/i>$3')
@@ -43,6 +45,7 @@
                             .replace(/(^|\s|[>])\*(.*?)\*($|\s|[<])/g, '$1<strong>$2<\/strong>$3');
     }
 
+    /** @type {NodeListOf<HTMLElement>} */
     var locales = d.querySelectorAll("[data-i18n]");
 
     for (var i = locales.length - 1; i >= 0; i--) {
@@ -54,6 +57,7 @@
     d.addEventListener("click", function (e) {
         if (e.button !== 0) return;
 
+        /** @type {HTMLAnchorElement} */
         var el = e.target;
 
         if (el.nodeName !== "A") {
@@ -79,6 +83,7 @@
         });
     }
 
+    /** @type {HTMLElement} */
     var se = d.scrollingElement || d.body;
 
     setTimeout(function () {

--- a/chrome/js/summary.js
+++ b/chrome/js/summary.js
@@ -9,6 +9,10 @@
 (function (w, d, u) {
     "use strict";
 
+    /**
+     * @param {HTMLDetailsElement} widget
+     * @param {`details:${string}`} key
+     */
     function setEvent(widget, key) {
         widget.addEventListener("toggle", function () {
             setStorage(key, widget.open);
@@ -20,6 +24,7 @@
     for (var i = details.length - 1; i >= 0; i--) {
         var widget = details[i],
             summary = widget.querySelector("[data-i18n]"),
+            /** @type {`details:${string}`} */
             key = "details:" + summary.getAttribute("data-i18n"),
             stored = getStorage(key);
 

--- a/chrome/js/toggle.js
+++ b/chrome/js/toggle.js
@@ -19,6 +19,9 @@
     var dataChange = { "data": u, "value": u };
     var dataEvent = new CustomEvent("change:data", { "detail": dataChange });
 
+    /**
+     * @param {Event} e
+     */
     function changeSwitch(e) {
         if (runtimeConnected()) {
             sync = true;
@@ -27,6 +30,9 @@
         }
     }
 
+    /**
+     * @param {Event} e
+     */
     function changeRadio(e) {
         if (runtimeConnected()) {
             sync = true;
@@ -36,7 +42,14 @@
         }
     }
 
+    /**
+     * @param {string} id
+     * @param {string} value
+     * @param {ExtraDataItem} response
+     * @param {boolean} trigger
+     */
     function updateRadio(id, value, response, trigger) {
+        /** @type {NodeListOf<HTMLInputElement>} */
         var els = d.querySelectorAll("input[type=radio][name='" + id + "']");
 
         for (var i = els.length - 1; i >= 0; i--) {
@@ -62,7 +75,9 @@
     }
 
     sendMessage({ "configs": true }, function (response) {
-        var current, toggles = d.querySelectorAll(".toggle input[type=checkbox]");
+        var current,
+            /** @type {NodeListOf<HTMLInputElement>} */
+            toggles = d.querySelectorAll(".toggle input[type=checkbox]");
 
         for (var i = toggles.length - 1; i >= 0; i--) {
             current = toggles[i];
@@ -90,12 +105,14 @@
         sync = false;
     });
 
+    /** @type {NodeListOf<HTMLInputElement>} */
     var toggles = d.querySelectorAll(".toggle input[type=checkbox]");
 
     for (var i = toggles.length - 1; i >= 0; i--) {
         toggles[i].addEventListener("change", changeSwitch);
     }
 
+    /** @type {NodeListOf<HTMLInputElement>} */
     var radios = d.querySelectorAll(".radio input[type=radio]");
 
     for (var i = radios.length - 1; i >= 0; i--) {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,12 @@
+var browser: undefined | typeof chrome
+
+interface DocumentEventMap {
+  "change:data": CustomEvent<{ data: string, value: string }>;
+}
+
+declare namespace chrome.tabs {
+  interface Tab {
+    /** The CookieStoreId used for the tab. See `@types/firefox-webext-browser`'s browser.tabs.Tab*/
+    cookieStoreId?: string | undefined;
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "none",
+    "target": "es2016",
+    "checkJs": true,
+    "strictNullChecks": false,
+    "strictFunctionTypes": true,
+    "lib": ["ES2016", "DOM"],
+    "types": ["chrome"]
+  },
+  "files": ["globals.d.ts"],
+  "include": ["chrome"],
+  "exclude": [
+    "node_modules",
+    "**/node_modules/*"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "prevent-duplicate-tabs",
+  "version": "0.7.11",
+  "description": "Prevents from automatically creating new tabs or repeating tabs when two or more tabs have the same addresses",
+  "keywords": [
+    "web-extension"
+  ],
+  "author": "Guilherme Nascimento",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/chrome": "^0.0.247"
+  }
+}


### PR DESCRIPTION
Fixes #36 (scenario 2)

I also add a bunch of jsdoc and such so typescript can understand the code. (also, changed `substr` to `slice`, since [`substr` is deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)). Could use `substring` instead, but i prefer `slice`). If undesired, we can just merge the commit with the change: https://github.com/brcontainer/prevent-duplicate-tabs/compare/main...forivall:prevent-duplicate-tabs:feature/switch-to-existing